### PR TITLE
feat: refresh auth screens styling

### DIFF
--- a/apps/frontend/src/features/auth/components/LoginForm.tsx
+++ b/apps/frontend/src/features/auth/components/LoginForm.tsx
@@ -30,32 +30,40 @@ export default function LoginForm() {
   };
 
   return (
-    <div className="mx-auto max-w-sm p-6 bg-white rounded shadow">
-      <h1 className="text-xl font-semibold mb-4">Ingresar</h1>
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-        <div>
-          <label className="block text-sm font-medium mb-1">Correo</label>
+    <div className="w-full max-w-md rounded-3xl border border-emerald-100/40 bg-white/95 p-10 shadow-2xl shadow-emerald-950/20 backdrop-blur">
+      <div className="mb-8 space-y-2 text-center">
+        <h2 className="text-3xl font-semibold text-emerald-950">Inicia sesión</h2>
+        <p className="text-sm text-emerald-900/70">Accede con tus credenciales corporativas.</p>
+      </div>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium uppercase tracking-wide text-emerald-900/80">
+            Correo
+          </label>
           <input
             type="email"
-            className="w-full border rounded px-3 py-2"
+            className="w-full rounded-xl border border-emerald-200/60 bg-white px-4 py-3 text-emerald-950 shadow-sm transition focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-400/50"
             placeholder="tucorreo@dominio.com"
             {...register('email')}
           />
-          {errors.email && <p className="text-sm text-red-600 mt-1">{errors.email.message}</p>}
+          {errors.email && <p className="text-sm text-red-600">{errors.email.message}</p>}
         </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">Contraseña</label>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium uppercase tracking-wide text-emerald-900/80">
+            Contraseña
+          </label>
           <input
             type="password"
-            className="w-full border rounded px-3 py-2"
+            className="w-full rounded-xl border border-emerald-200/60 bg-white px-4 py-3 text-emerald-950 shadow-sm transition focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-400/50"
+            placeholder="••••••••"
             {...register('password')}
           />
-          {errors.password && <p className="text-sm text-red-600 mt-1">{errors.password.message}</p>}
+          {errors.password && <p className="text-sm text-red-600">{errors.password.message}</p>}
         </div>
         <button
           type="submit"
           disabled={isPending}
-          className="w-full py-2 rounded bg-black text-white disabled:opacity-50"
+          className="w-full rounded-xl bg-emerald-900 px-4 py-3 text-sm font-semibold uppercase tracking-wide text-white transition hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isPending ? 'Ingresando…' : 'Ingresar'}
         </button>

--- a/apps/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/apps/frontend/src/features/auth/pages/LoginPage.tsx
@@ -2,8 +2,20 @@ import LoginForm from '../components/LoginForm';
 
 export default function LoginPage() {
   return (
-    <div className="min-h-dvh grid place-items-center bg-gray-50">
-      <LoginForm />
+    <div className="min-h-dvh bg-gradient-to-br from-emerald-950 via-emerald-900 to-emerald-950 px-6 py-16">
+      <div className="mx-auto flex max-w-5xl flex-col items-center justify-center gap-10 text-center text-white">
+        <div className="space-y-4">
+          <span className="rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-medium uppercase tracking-[0.3em] text-emerald-100">
+            Evalutia
+          </span>
+          <h1 className="text-4xl font-semibold sm:text-5xl">Portal de acceso seguro</h1>
+          <p className="text-lg text-emerald-100/90">
+            Inicia sesión para continuar con tus evaluaciones y reportes. Un entorno minimalista
+            y diseñado para mantener tu enfoque.
+          </p>
+        </div>
+        <LoginForm />
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/routes/AppRoutes.tsx
+++ b/apps/frontend/src/routes/AppRoutes.tsx
@@ -8,9 +8,17 @@ const queryClient = new QueryClient();
 
 function Dashboard() {
   return (
-    <div className="p-6">
-      <h1 className="text-xl font-semibold">Dashboard</h1>
-      <p className="text-gray-600">Bienvenido al portal Evalutia.</p>
+    <div className="min-h-dvh bg-gradient-to-br from-emerald-950 via-emerald-900 to-emerald-950 px-6 py-16">
+      <div className="mx-auto flex max-w-2xl flex-col items-center justify-center gap-6 text-center">
+        <span className="rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-medium uppercase tracking-[0.3em] text-emerald-100">
+          Panel principal
+        </span>
+        <h1 className="text-4xl font-semibold text-white sm:text-5xl">Bienvenido al portal Evalutia</h1>
+        <p className="text-lg leading-relaxed text-emerald-100/90">
+          Gestiona y visualiza tus métricas clave en un entorno claro, moderno y enfocado
+          en lo que realmente importa.
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refresh the login screen with a centered hero introduction and refined form styling in emerald and white
- restyle the dashboard view to match the minimalist emerald gradient aesthetic

## Testing
- npm run lint *(fails: pre-existing lint errors in auth api and hooks)*

------
https://chatgpt.com/codex/tasks/task_b_68d421b05ef48320968a943d006fbe34